### PR TITLE
Avoid __builtin_prefetch() in mcdb_findtagnext()

### DIFF
--- a/mcdb.c
+++ b/mcdb.c
@@ -147,7 +147,6 @@ mcdb_findtagnext(struct mcdb * const restrict m,
             khash= *(uint32_t *)ptr; /* m->khash stored bigendian */
             vpos = uint32_strunpack_bigendian_aligned_macro(ptr+4);
             ptr  = mptr + vpos;
-            __builtin_prefetch((char *)ptr, 0, PLASMA_ATTR_MM_HINT_T2);
             if (__builtin_expect((!vpos), 0))
                 break;
             ++m->loop;
@@ -171,7 +170,6 @@ mcdb_findtagnext(struct mcdb * const restrict m,
             khash   = *(uint32_t *)ptr; /* m->khash stored bigendian */
             m->klen = uint32_strunpack_bigendian_aligned_macro(ptr+4);
             vpos    = uint64_strunpack_bigendian_aligned_macro(ptr+8);
-            __builtin_prefetch((char *)mptr+vpos+4, 0, PLASMA_ATTR_MM_HINT_T2);
             if (__builtin_expect((!vpos), 0))
                 break;
             ++m->loop;

--- a/mcdb.c
+++ b/mcdb.c
@@ -146,7 +146,6 @@ mcdb_findtagnext(struct mcdb * const restrict m,
                 m->kpos = m->hpos;
             khash= *(uint32_t *)ptr; /* m->khash stored bigendian */
             vpos = uint32_strunpack_bigendian_aligned_macro(ptr+4);
-            ptr  = mptr + vpos;
             if (__builtin_expect((!vpos), 0))
                 break;
             ++m->loop;


### PR DESCRIPTION
Removing prefetch of every value location in loop. Resulted in 
- 33% improvement in 100% miss case, 
- 10% improvement in 10% miss case, and
- 11% improvement in 0% miss case.
