### PR TITLE
Avoid __builtin_expect() on vpos

### DIFF
--- a/mcdb.c
+++ b/mcdb.c
@@ -146,7 +146,7 @@ mcdb_findtagnext(struct mcdb * const restrict m,
                 m->kpos = m->hpos;
             khash= *(uint32_t *)ptr; /* m->khash stored bigendian */
             vpos = uint32_strunpack_bigendian_aligned_macro(ptr+4);
-            if (__builtin_expect((!vpos), 0))
+            if (!vpos)
                 break;
             ++m->loop;
             if (khash == m->khash) {
@@ -169,7 +169,7 @@ mcdb_findtagnext(struct mcdb * const restrict m,
             khash   = *(uint32_t *)ptr; /* m->khash stored bigendian */
             m->klen = uint32_strunpack_bigendian_aligned_macro(ptr+4);
             vpos    = uint64_strunpack_bigendian_aligned_macro(ptr+8);
-            if (__builtin_expect((!vpos), 0))
+            if (!vpos)
                 break;
             ++m->loop;
             if (khash == m->khash && m->klen == klen+(tagc!=0)) {


### PR DESCRIPTION
Seems the code assumes that all lookup keys will have a value in mcdb, and optimizes for this path. Removing this assumption, resulted in improvement in lookup time when keys doesnt exist.
